### PR TITLE
Add entity namespaces to chronoctl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Added support for entity namespaces
+
 ## v1.5.0
 
 ### Added

--- a/src/cmd/pkg/client/client.go
+++ b/src/cmd/pkg/client/client.go
@@ -48,6 +48,8 @@ const (
 	ChronosphereOrgKey = "CHRONOSPHERE_ORG" // fallback for CHRONOSPHERE_ORG_NAME
 	// ChronosphereAPITokenKey is the environment variable that specifies the Chronosphere API token
 	ChronosphereAPITokenKey = "CHRONOSPHERE_API_TOKEN"
+	// ChronosphereEntityNamespace is the environment variable that specifies the Chronosphere entity namespace
+	ChronosphereEntityNamespace = "CHRONOSPHERE_ENTITY_NAMESPACE"
 )
 
 // Clients is a list of clients our generated CLI needs access to.
@@ -129,6 +131,7 @@ func (f *Flags) Transport(component transport.Component, basePath string) (*http
 		InsecureSkipVerify: f.InsecureSkipVerify,
 		AllowHTTP:          f.AllowHTTP,
 		DefaultBasePath:    basePath,
+		EntityNamespace:    f.getEntityNamespace(),
 	})
 	if err != nil {
 		return nil, err
@@ -157,6 +160,13 @@ func (f *Flags) AddFlags(cmd *cobra.Command) {
 // Timeout returns the value of the timeout flag as a time.Duration.
 func (f *Flags) Timeout() time.Duration {
 	return time.Duration(f.TimeoutSeconds) * time.Second
+}
+
+func (f *Flags) getEntityNamespace() string {
+	if ns := os.Getenv(ChronosphereEntityNamespace); ns != "" {
+		return ns
+	}
+	return ""
 }
 
 func (f *Flags) getAPIToken() (string, error) {

--- a/src/cmd/pkg/client/client_test.go
+++ b/src/cmd/pkg/client/client_test.go
@@ -228,7 +228,7 @@ func TestClientFlagsTransport(t *testing.T) {
 				assert.NotNil(t, tp.DefaultAuthentication)
 
 				if tt.wantInsecureSkipVerify {
-					httpTransport := tp.Transport.(swagger.RequestIDTrailerTransport).RT.(transport.VersionHeaderTransport).Rt.(*http.Transport) //nolint:errcheck
+					httpTransport := tp.Transport.(swagger.RequestIDTrailerTransport).RT.(transport.CustomHeaderTransport).Rt.(*http.Transport) //nolint:errcheck
 					assert.Equal(t, tt.wantInsecureSkipVerify, httpTransport.TLSClientConfig.InsecureSkipVerify)
 				}
 			})


### PR DESCRIPTION
This PR adds support for entity namespaces to chronoctl. It is
only exposed via an environment variable. It is not a CLI flag
because it is not meant to be used by a normal everyday user
since it requires internal Chronosphere credentials

sc-90822