### PR TITLE
Fix help text for singleton delete commands

### DIFF
--- a/src/generated/cli/configunstable/trace_tail_sampling_rules.gen.go
+++ b/src/generated/cli/configunstable/trace_tail_sampling_rules.gen.go
@@ -311,9 +311,10 @@ func newTraceTailSamplingRulesDeleteCmd() *cobra.Command {
 	outputFlags := output.NewFlags(output.WithoutOutputDirectory(), output.WithoutCreateFilePerObject())
 
 	cmd := &cobra.Command{
-		Use:     "delete <slug>",
+		Use:     "delete",
 		GroupID: groups.Commands.ID,
-		Short:   "Deletes a single TraceTailSamplingRules by slug",
+		Short:   "Deletes the TraceTailSamplingRules singleton",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), clientFlags.Timeout())
 			defer cancel()

--- a/src/generated/cli/configv1/otel_metrics_ingestion.gen.go
+++ b/src/generated/cli/configv1/otel_metrics_ingestion.gen.go
@@ -311,9 +311,10 @@ func newOtelMetricsIngestionDeleteCmd() *cobra.Command {
 	outputFlags := output.NewFlags(output.WithoutOutputDirectory(), output.WithoutCreateFilePerObject())
 
 	cmd := &cobra.Command{
-		Use:     "delete <slug>",
+		Use:     "delete",
 		GroupID: groups.Commands.ID,
-		Short:   "Deletes a single OtelMetricsIngestion by slug",
+		Short:   "Deletes the OtelMetricsIngestion singleton",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), clientFlags.Timeout())
 			defer cancel()

--- a/src/generated/cli/configv1/resource_pools.gen.go
+++ b/src/generated/cli/configv1/resource_pools.gen.go
@@ -311,9 +311,10 @@ func newResourcePoolsDeleteCmd() *cobra.Command {
 	outputFlags := output.NewFlags(output.WithoutOutputDirectory(), output.WithoutCreateFilePerObject())
 
 	cmd := &cobra.Command{
-		Use:     "delete <slug>",
+		Use:     "delete",
 		GroupID: groups.Commands.ID,
-		Short:   "Deletes a single ResourcePools by slug",
+		Short:   "Deletes the ResourcePools singleton",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), clientFlags.Timeout())
 			defer cancel()

--- a/src/generated/cli/configv1/trace_behavior_config.gen.go
+++ b/src/generated/cli/configv1/trace_behavior_config.gen.go
@@ -311,9 +311,10 @@ func newTraceBehaviorConfigDeleteCmd() *cobra.Command {
 	outputFlags := output.NewFlags(output.WithoutOutputDirectory(), output.WithoutCreateFilePerObject())
 
 	cmd := &cobra.Command{
-		Use:     "delete <slug>",
+		Use:     "delete",
 		GroupID: groups.Commands.ID,
-		Short:   "Deletes a single TraceBehaviorConfig by slug",
+		Short:   "Deletes the TraceBehaviorConfig singleton",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), clientFlags.Timeout())
 			defer cancel()

--- a/src/generated/cli/configv1/trace_tail_sampling_rules.gen.go
+++ b/src/generated/cli/configv1/trace_tail_sampling_rules.gen.go
@@ -311,9 +311,10 @@ func newTraceTailSamplingRulesDeleteCmd() *cobra.Command {
 	outputFlags := output.NewFlags(output.WithoutOutputDirectory(), output.WithoutCreateFilePerObject())
 
 	cmd := &cobra.Command{
-		Use:     "delete <slug>",
+		Use:     "delete",
 		GroupID: groups.Commands.ID,
-		Short:   "Deletes a single TraceTailSamplingRules by slug",
+		Short:   "Deletes the TraceTailSamplingRules singleton",
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx, cancel := context.WithTimeout(cmd.Context(), clientFlags.Timeout())
 			defer cancel()

--- a/tools/cmd/chronogen/clitemplates/delete.go.tmpl
+++ b/tools/cmd/chronogen/clitemplates/delete.go.tmpl
@@ -27,11 +27,16 @@ func new{{ .Name }}DeleteCmd() *cobra.Command {
 	{{- end }}
 
 	cmd := &cobra.Command{
+		{{- if .Entity.IsNotSingleton }}
 		Use: "delete <slug>",
 		GroupID: groups.Commands.ID,
 		Short: "Deletes a single {{ .Name }} by slug",
-		{{- if .Entity.IsNotSingleton }}
 		Args: cobra.ExactArgs(1),
+		{{- else }}
+		Use: "delete",
+		GroupID: groups.Commands.ID,
+		Short: "Deletes the {{ .Name }} singleton",
+		Args: cobra.NoArgs,
 		{{- end }}
 		RunE: func(cmd *cobra.Command, args []string) error{
 			ctx, cancel := context.WithTimeout(cmd.Context(), clientFlags.Timeout())


### PR DESCRIPTION
The `<singleton> delete` commands were mistakenly documented as expecting a `<slug>` argument.

They also used to silently accept unexpected arguments, which could cause surprising behavior (delete the whole singleton) when the user thought they could delete only a portion by slug.