### PR TITLE
Release v1.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,13 @@
 
 ## Unreleased
 
+## v1.10.1
+
+No changes
+
 ## v1.10.0
 
-### Added 
+### Added
 * Adds new resource `v1/config/LogScaleAction`
 * Adds new resource `v1/config/LogScaleAlert`
 * Adds new field `pool.allocation.fixed_values` to `v1/config/ResourcePools`


### PR DESCRIPTION
I yanked and retag'd a different SHA with v1.10.0, which I thought would be okay, but on my machine I ran `go get ...` on the old SHA so pulling v1.10.0 from the golang proxy causes a mismatched SHA error. 