### PR TITLE
chronoctl auth whoami

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 Added:
 * Adds support for pool PriorityThresholds in `v1/config/ResourcePools`
+* Adds `chronoctl auth whoami` which prints the current user 
 
 ## v1.11.0
 

--- a/src/cmd/pkg/auth/auth_test.go
+++ b/src/cmd/pkg/auth/auth_test.go
@@ -257,10 +257,7 @@ func TestAuthLogin(t *testing.T) {
 			tmpDir := t.TempDir()
 			store := token.NewFileStore(tmpDir)
 			if tt.defaultOrg != "" {
-				require.NoError(t, store.Put(defaultOrgPath, token.Token{
-					Value:  []byte(tt.defaultOrg),
-					Expiry: time.Now().Add(time.Hour * 24 * 365),
-				}))
+				require.NoError(t, store.SetDefaultOrg(tt.defaultOrg))
 			}
 
 			c := subcommand{store: store}
@@ -292,10 +289,10 @@ func TestAuthLogin(t *testing.T) {
 			require.Equal(t, tt.wantSessionID, string(sessionToken.Value))
 
 			// Verify that the correct org is set as default if applicable
-			defaultOrg, err := store.Get(defaultOrgPath)
+			defaultOrg, err := store.GetDefaultOrg()
 			if tt.wantDefaultTenant {
 				require.NoError(t, err)
-				require.Equal(t, tenantName, string(defaultOrg.Value))
+				require.Equal(t, tenantName, defaultOrg)
 			} else {
 				require.ErrorIs(t, err, token.ErrNotExist)
 			}
@@ -334,10 +331,7 @@ func TestAuthSetDefaultOrg(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			store := token.NewFileStore(t.TempDir())
 			if tt.existingDefaultOrg != "" {
-				require.NoError(t, store.Put(defaultOrgPath, token.Token{
-					Value:  []byte(tt.existingDefaultOrg),
-					Expiry: time.Now().Add(time.Hour * 24 * 365),
-				}))
+				require.NoError(t, store.SetDefaultOrg(tt.existingDefaultOrg))
 			}
 
 			c := subcommand{store: store}
@@ -350,9 +344,9 @@ func TestAuthSetDefaultOrg(t *testing.T) {
 			}
 			require.NoError(t, err)
 
-			defaultOrg, err := store.Get(defaultOrgPath)
+			defaultOrg, err := store.GetDefaultOrg()
 			require.NoError(t, err)
-			require.Equal(t, tt.args[0], string(defaultOrg.Value))
+			require.Equal(t, tt.args[0], defaultOrg)
 		})
 	}
 }
@@ -452,7 +446,7 @@ func TestAuthList(t *testing.T) {
 		{
 			name: "tokens with default",
 			tokens: map[string]token.Token{
-				defaultOrgPath: {
+				"default-org": {
 					Value:  []byte(tenantName),
 					Expiry: time.Now().Add(time.Hour),
 				},
@@ -524,7 +518,7 @@ func TestAuthList(t *testing.T) {
 		{
 			name: "expired default",
 			tokens: map[string]token.Token{
-				defaultOrgPath: {
+				"default-org": {
 					Value:  []byte(tenantName),
 					Expiry: time.Now().Add(-time.Hour),
 				},
@@ -549,7 +543,7 @@ func TestAuthList(t *testing.T) {
 		{
 			name: "default set but no tokens",
 			tokens: map[string]token.Token{
-				defaultOrgPath: {
+				"default-org": {
 					Value:  []byte(tenantName),
 					Expiry: time.Now().Add(time.Hour),
 				},

--- a/src/cmd/pkg/auth/loginserver.go
+++ b/src/cmd/pkg/auth/loginserver.go
@@ -43,10 +43,7 @@ func (w *wrongTenantError) Error() string {
 }
 
 func newLoginServer(store *token.Store, openFunc browserOpenFunc, opts *loginOpts) (*loginServer, error) {
-	var defaultOrg string
-	if defaultOrgToken, err := store.Get(defaultOrgPath); err == nil {
-		defaultOrg = string(defaultOrgToken.Value)
-	}
+	defaultOrg, _ := store.GetDefaultOrg()
 
 	orgName := cmp.Or(
 		opts.orgName,
@@ -148,7 +145,7 @@ func (s *loginServer) login(ctx context.Context, stdin io.Reader, stdout, stderr
 		if s.skipSetDefaultOrg {
 			return nil
 		}
-		if err := setDefaultOrg(s.store, s.org); err != nil {
+		if err := s.store.SetDefaultOrg(s.org); err != nil {
 			fmt.Fprintf(stderr, "Failed to set default organization: %s\n", err) //nolint:errcheck
 		}
 		return nil

--- a/src/cmd/pkg/client/client.go
+++ b/src/cmd/pkg/client/client.go
@@ -28,7 +28,6 @@ import (
 	"github.com/go-openapi/strfmt"
 	"github.com/spf13/cobra"
 
-	"github.com/chronosphereio/chronoctl-core/src/cmd/pkg/auth"
 	"github.com/chronosphereio/chronoctl-core/src/cmd/pkg/env"
 	"github.com/chronosphereio/chronoctl-core/src/cmd/pkg/token"
 	"github.com/chronosphereio/chronoctl-core/src/cmd/pkg/transport"
@@ -240,7 +239,7 @@ func (f *Flags) checkDefaultOrg() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	defaultOrg, err := auth.GetDefaultOrg(store)
+	defaultOrg, err := store.GetDefaultOrg()
 	if err != nil {
 		return "", fmt.Errorf("unable to get default organization: %v", err)
 	}
@@ -251,7 +250,7 @@ func (f *Flags) getStore() (*token.Store, error) {
 	if f.TokenStoreDir != "" {
 		return token.NewFileStore(f.TokenStoreDir), nil
 	}
-	store, err := auth.NewChronoctlStore()
+	store, err := token.NewChronoctlStore()
 	if err != nil {
 		return nil, fmt.Errorf("unable to get chronoctl store: %v", err)
 	}

--- a/src/cmd/pkg/client/client.go
+++ b/src/cmd/pkg/client/client.go
@@ -19,6 +19,8 @@ package client
 import (
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
 	"net/url"
 	"os"
 	"strings"
@@ -137,6 +139,24 @@ func (f *Flags) Transport(component transport.Component, basePath string) (*http
 	}
 
 	return transport, nil
+}
+
+// NewRequest decorates stdlib http.NewRequest with the API url and auth headers.
+func (f *Flags) NewRequest(method, basePath string, body io.Reader) (*http.Request, error) {
+	apiURL, err := f.getAPIURL(basePath)
+	if err != nil {
+		return nil, err
+	}
+	apiToken, err := f.getAPIToken(apiURL)
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequest(method, apiURL, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Add("API-Token", apiToken)
+	return req, nil
 }
 
 // AddFlags adds client flags to a Cobra command.

--- a/src/cmd/pkg/token/token.go
+++ b/src/cmd/pkg/token/token.go
@@ -196,6 +196,7 @@ func (s *Store) GetDefaultOrg() (string, error) {
 	return string(org.Value), nil
 }
 
+// SetDefaultOrg sets the token for the default org
 func (s *Store) SetDefaultOrg(org string) error {
 	return errors.WithStack(s.Put(defaultOrgPath, Token{
 		Value: []byte(org),


### PR DESCRIPTION
Adds `chronoctl auth whoami` which resolves a given token to the user to which it belongs. whoami supports the standard mechanisms for providing credentials, i.e. `--api-token`, `CHRONOSPHERE_API_TOKEN`, and local token storage. If multiple credentials are present, it determines which credential to resolve in the same manner as all other chronoctl commands.

Reviewable by commit