### PR TITLE
Add tests for NewRequest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Added:
 * Adds support for pool PriorityThresholds in `v1/config/ResourcePools`
-* Adds `chronoctl auth whoami` which prints the current user 
+* Adds `chronoctl auth whoami` which prints the current user
 
 ## v1.11.0
 

--- a/src/cmd/pkg/client/client_test.go
+++ b/src/cmd/pkg/client/client_test.go
@@ -347,6 +347,9 @@ func TestClientFlagsNewRequest(t *testing.T) {
 				APITokenFilename: "./testdata/token",
 				TokenStoreDir:    t.TempDir(),
 			},
+			env: envVars{
+				token: "bad-token",
+			},
 			basePath:     "/api",
 			wantToken:    "token-from-file",
 			wantHost:     "myorg.chronosphere.io",

--- a/src/cmd/pkg/client/client_test.go
+++ b/src/cmd/pkg/client/client_test.go
@@ -308,9 +308,8 @@ func TestClientFlagsNewRequest(t *testing.T) {
 		{
 			name: "all necessary flags specified",
 			flags: &Flags{
-				APIUrl:        TestChronosphereURL,
-				APIToken:      "token",
-				TokenStoreDir: t.TempDir(),
+				APIUrl:   TestChronosphereURL,
+				APIToken: "token",
 			},
 			basePath:     "/api",
 			wantToken:    "token",
@@ -323,7 +322,6 @@ func TestClientFlagsNewRequest(t *testing.T) {
 				APIUrl:           TestChronosphereURL,
 				APIToken:         "token-param",
 				APITokenFilename: "./testdata/token",
-				TokenStoreDir:    t.TempDir(),
 			},
 			basePath: "/api",
 			wantErr:  "only one of --api-token and --api-token-filename can be set",
@@ -331,9 +329,8 @@ func TestClientFlagsNewRequest(t *testing.T) {
 		{
 			name: "--api-token overrides environment variable",
 			flags: &Flags{
-				APIUrl:        TestChronosphereURL,
-				APIToken:      "token-param",
-				TokenStoreDir: t.TempDir(),
+				APIUrl:   TestChronosphereURL,
+				APIToken: "token-param",
 			},
 			basePath:     "/api",
 			wantToken:    "token-param",
@@ -345,7 +342,6 @@ func TestClientFlagsNewRequest(t *testing.T) {
 			flags: &Flags{
 				APIUrl:           TestChronosphereURL,
 				APITokenFilename: "./testdata/token",
-				TokenStoreDir:    t.TempDir(),
 			},
 			env: envVars{
 				token: "bad-token",
@@ -360,7 +356,6 @@ func TestClientFlagsNewRequest(t *testing.T) {
 			flags: &Flags{
 				APIUrl:           TestChronosphereURL,
 				APITokenFilename: "./testdata/no_token",
-				TokenStoreDir:    t.TempDir(),
 			},
 			basePath: "/api",
 			wantErr:  "reading api token from file ./testdata/no_token: open ./testdata/no_token: no such file or directory",
@@ -368,8 +363,7 @@ func TestClientFlagsNewRequest(t *testing.T) {
 		{
 			name: "fall back to environment variable for API token",
 			flags: &Flags{
-				APIUrl:        TestChronosphereURL,
-				TokenStoreDir: t.TempDir(),
+				APIUrl: TestChronosphereURL,
 			},
 			env:          envVars{token: "token"},
 			basePath:     "/api",
@@ -380,8 +374,7 @@ func TestClientFlagsNewRequest(t *testing.T) {
 		{
 			name: "token and store not set",
 			flags: &Flags{
-				APIUrl:        TestChronosphereURL,
-				TokenStoreDir: t.TempDir(),
+				APIUrl: TestChronosphereURL,
 			},
 			basePath: "/api",
 			wantErr:  "client API token must be provided via --api-token, --api-token-filename, CHRONOSPHERE_API_TOKEN environment variable, or by authenticating with 'auth login'",
@@ -409,8 +402,7 @@ func TestClientFlagsNewRequest(t *testing.T) {
 		{
 			name: "organization and default org not set",
 			flags: &Flags{
-				APIToken:      "token",
-				TokenStoreDir: t.TempDir(),
+				APIToken: "token",
 			},
 			basePath: "/api",
 			wantErr:  "organization must be provided as a flag, via the CHRONOSPHERE_ORG_NAME environment variable, or by setting a default org when the API URL isn't set",
@@ -418,9 +410,8 @@ func TestClientFlagsNewRequest(t *testing.T) {
 		{
 			name: "fall back to org name flag for organization name",
 			flags: &Flags{
-				APIToken:      "token",
-				OrgName:       "specialorg",
-				TokenStoreDir: t.TempDir(),
+				APIToken: "token",
+				OrgName:  "specialorg",
 			},
 			basePath:     "/api",
 			wantToken:    "token",
@@ -461,9 +452,8 @@ func TestClientFlagsNewRequest(t *testing.T) {
 		{
 			name: "invalid URL",
 			flags: &Flags{
-				APIUrl:        TestBadURL,
-				APIToken:      "token",
-				TokenStoreDir: t.TempDir(),
+				APIUrl:   TestBadURL,
+				APIToken: "token",
 			},
 			basePath: "/api",
 			wantErr:  `parse "://bad.domain.io": missing protocol scheme`,
@@ -474,6 +464,9 @@ func TestClientFlagsNewRequest(t *testing.T) {
 			t.Setenv(env.ChronosphereAPITokenKey, tt.env.token)
 			t.Setenv(env.ChronosphereOrgNameKey, tt.env.org)
 
+			if tt.flags.TokenStoreDir == "" {
+				tt.flags.TokenStoreDir = t.TempDir()
+			}
 			req, err := tt.flags.NewRequest(http.MethodGet, tt.basePath, nil /* body */)
 			if tt.wantErr != "" {
 				assert.ErrorContains(t, err, tt.wantErr)

--- a/src/cmd/pkg/client/client_test.go
+++ b/src/cmd/pkg/client/client_test.go
@@ -93,7 +93,7 @@ func TestClientFlagsTransport(t *testing.T) {
 			wantBasePath: "/api",
 		},
 		{
-			name: "fall back to environment variable for organization name",
+			name: "fall back to org name flag for organization name",
 			flags: &Flags{
 				APIToken:      "token",
 				OrgName:       "specialorg",
@@ -287,6 +287,201 @@ func TestClientFlagsTransport(t *testing.T) {
 				}
 			})
 		}
+	}
+}
+
+func TestClientFlagsNewRequest(t *testing.T) {
+	type envVars struct {
+		token string
+		org   string
+	}
+	tests := []struct {
+		name         string
+		flags        *Flags
+		env          envVars
+		basePath     string
+		wantToken    string
+		wantErr      string
+		wantHost     string
+		wantBasePath string
+	}{
+		{
+			name: "all necessary flags specified",
+			flags: &Flags{
+				APIUrl:        TestChronosphereURL,
+				APIToken:      "token",
+				TokenStoreDir: t.TempDir(),
+			},
+			basePath:     "/api",
+			wantToken:    "token",
+			wantHost:     "myorg.chronosphere.io",
+			wantBasePath: "/api",
+		},
+		{
+			name: "--api-token and --api-token-filename are exclusive",
+			flags: &Flags{
+				APIUrl:           TestChronosphereURL,
+				APIToken:         "token-param",
+				APITokenFilename: "./testdata/token",
+				TokenStoreDir:    t.TempDir(),
+			},
+			basePath: "/api",
+			wantErr:  "only one of --api-token and --api-token-filename can be set",
+		},
+		{
+			name: "--api-token overrides environment variable",
+			flags: &Flags{
+				APIUrl:        TestChronosphereURL,
+				APIToken:      "token-param",
+				TokenStoreDir: t.TempDir(),
+			},
+			basePath:     "/api",
+			wantToken:    "token-param",
+			wantHost:     "myorg.chronosphere.io",
+			wantBasePath: "/api",
+		},
+		{
+			name: "--api-token-filename parameter overrides environment variable",
+			flags: &Flags{
+				APIUrl:           TestChronosphereURL,
+				APITokenFilename: "./testdata/token",
+				TokenStoreDir:    t.TempDir(),
+			},
+			basePath:     "/api",
+			wantToken:    "token-from-file",
+			wantHost:     "myorg.chronosphere.io",
+			wantBasePath: "/api",
+		},
+		{
+			name: "invalid --api-token-filename parameter returns error",
+			flags: &Flags{
+				APIUrl:           TestChronosphereURL,
+				APITokenFilename: "./testdata/no_token",
+				TokenStoreDir:    t.TempDir(),
+			},
+			basePath: "/api",
+			wantErr:  "reading api token from file ./testdata/no_token: open ./testdata/no_token: no such file or directory",
+		},
+		{
+			name: "fall back to environment variable for API token",
+			flags: &Flags{
+				APIUrl:        TestChronosphereURL,
+				TokenStoreDir: t.TempDir(),
+			},
+			env:          envVars{token: "token"},
+			basePath:     "/api",
+			wantToken:    "token",
+			wantHost:     "myorg.chronosphere.io",
+			wantBasePath: "/api",
+		},
+		{
+			name: "token and store not set",
+			flags: &Flags{
+				APIUrl:        TestChronosphereURL,
+				TokenStoreDir: t.TempDir(),
+			},
+			basePath: "/api",
+			wantErr:  "client API token must be provided via --api-token, --api-token-filename, CHRONOSPHERE_API_TOKEN environment variable, or by authenticating with 'auth login'",
+		},
+		{
+			name: "token not set falls back to token store",
+			flags: &Flags{
+				APIUrl: TestChronosphereURL,
+				TokenStoreDir: func() string {
+					dir := t.TempDir()
+					// Populate store directory with a token
+					store := token.NewFileStore(dir)
+					require.NoError(t, store.Put("myorg", token.Token{
+						Value:  []byte("token"),
+						Expiry: time.Now().Add(time.Hour),
+					}))
+					return dir
+				}(),
+			},
+			basePath:     "/api",
+			wantToken:    "token",
+			wantHost:     "myorg.chronosphere.io",
+			wantBasePath: "/api",
+		},
+		{
+			name: "organization and default org not set",
+			flags: &Flags{
+				APIToken:      "token",
+				TokenStoreDir: t.TempDir(),
+			},
+			basePath: "/api",
+			wantErr:  "organization must be provided as a flag, via the CHRONOSPHERE_ORG_NAME environment variable, or by setting a default org when the API URL isn't set",
+		},
+		{
+			name: "fall back to org name flag for organization name",
+			flags: &Flags{
+				APIToken:      "token",
+				OrgName:       "specialorg",
+				TokenStoreDir: t.TempDir(),
+			},
+			basePath:     "/api",
+			wantToken:    "token",
+			wantHost:     "specialorg.chronosphere.io",
+			wantBasePath: "/api",
+		},
+		{
+			name: "organization not set falls back to default",
+			flags: &Flags{
+				APIToken: "token",
+				TokenStoreDir: func() string {
+					dir := t.TempDir()
+					// Populate store directory with a token
+					store := token.NewFileStore(dir)
+					require.NoError(t, store.Put("default-org", token.Token{
+						Value:  []byte("myorg"),
+						Expiry: time.Now().Add(time.Hour),
+					}))
+					return dir
+				}(),
+			},
+			basePath:     "/api",
+			wantToken:    "token",
+			wantHost:     "myorg.chronosphere.io",
+			wantBasePath: "/api",
+		},
+		{
+			name: "api url overrides the base path",
+			flags: &Flags{
+				APIUrl:   "https://myorg.chronosphere.io/notthebasepath",
+				APIToken: "token",
+			},
+			basePath:     "/api",
+			wantToken:    "token",
+			wantHost:     "myorg.chronosphere.io",
+			wantBasePath: "/notthebasepath",
+		},
+		{
+			name: "invalid URL",
+			flags: &Flags{
+				APIUrl:        TestBadURL,
+				APIToken:      "token",
+				TokenStoreDir: t.TempDir(),
+			},
+			basePath: "/api",
+			wantErr:  `parse "://bad.domain.io": missing protocol scheme`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv(env.ChronosphereAPITokenKey, tt.env.token)
+			t.Setenv(env.ChronosphereOrgNameKey, tt.env.org)
+
+			req, err := tt.flags.NewRequest(http.MethodGet, tt.basePath, nil /* body */)
+			if tt.wantErr != "" {
+				assert.ErrorContains(t, err, tt.wantErr)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantHost, req.Host)
+			assert.Equal(t, tt.wantBasePath, req.URL.Path)
+			assert.Equal(t, tt.wantToken, req.Header.Get("API-Token"))
+		})
 	}
 }
 


### PR DESCRIPTION
Adds tests to the NewRequests function to guarantee that we set the org name and api token correctly.