### PR TITLE
Add support for LogIngestConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Releases
 
 ## Unreleased
+* Add support for resource `v1/config/LogIngestConfig
 
 ## v1.13.0
 Added:

--- a/src/generated/cli/configv1/log_ingest_config.gen.go
+++ b/src/generated/cli/configv1/log_ingest_config.gen.go
@@ -345,7 +345,7 @@ func newLogIngestConfigDeleteCmd() *cobra.Command {
 }
 
 const LogIngestConfigScaffoldYAML = `api_version: v1/config
-kind: LogIngestConfigs
+kind: LogIngestConfig
 spec:
     # The ordered list of parsers to run on ingested logs. The first parser which matches the log is used.
     parsers:


### PR DESCRIPTION
Configures saffolding for LogIngestConfig to use `Kind: LogIngestConfig` instead of `Kind: LogIngestConfigs`.