### PR TITLE
Release v1.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,15 @@
 # Releases
 
 ## Unreleased
-* Add support for resource `v1/config/LogIngestConfig
-* Internal: upgrade to Go 1.24
-* Internal: pull in latest API changes
+
+## v1.14.0
+
+Added:
+* Add support for resource `v1/config/LogIngestConfig`
 * Add support for TimeSlice SLOs
 
 ## v1.13.0
+
 Added:
 * Move SLOs stable public API in `v1/config/Slos`
 


### PR DESCRIPTION
Releasing a new version of chronoctl. Here's the list of commits that are part of the new release


- dc74316 Update swagger with latest
- 564cf14 Upgrade github.com/prometheus/prometheus to v3.3.0
- 788d200 make update-swagger
- 9738bba Upgrade to go 1.24
- d71ba1e Add support for LogIngestConfig

