### PR TITLE
Fix singleton scaffold kind for ConsumptionConfig, LogAllocationConfig, LogControlConfig, and TraceBehaviorConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 * Update parser resource in `v1/config/LogIngestConfig`
 * Adds unstable resource `unstable/config/AzureMetricsIntegration`
+* Fix ConsumptionConfig, LogAllocationConfig, LogControlConfig, and TraceBehaviorConfig kinds in scaffold command
 
 ## v1.14.0
 

--- a/src/generated/cli/configunstable/consumption_config.gen.go
+++ b/src/generated/cli/configunstable/consumption_config.gen.go
@@ -345,7 +345,7 @@ func newConsumptionConfigDeleteCmd() *cobra.Command {
 }
 
 const ConsumptionConfigScaffoldYAML = `api_version: unstable/config
-kind: ConsumptionConfigs
+kind: ConsumptionConfig
 spec:
     # partitions define non-overlapping groupings of telemetry. Partitions are
     # defined in order of precedence, where incoming requests are allocated to

--- a/src/generated/cli/configv1/log_allocation_config.gen.go
+++ b/src/generated/cli/configv1/log_allocation_config.gen.go
@@ -345,7 +345,7 @@ func newLogAllocationConfigDeleteCmd() *cobra.Command {
 }
 
 const LogAllocationConfigScaffoldYAML = `api_version: v1/config
-kind: LogAllocationConfigs
+kind: LogAllocationConfig
 spec:
     # Defines datasets and budget allocations. Datasets are evaluated in order.
     dataset_allocations:

--- a/src/generated/cli/configv1/log_control_config.gen.go
+++ b/src/generated/cli/configv1/log_control_config.gen.go
@@ -345,7 +345,7 @@ func newLogControlConfigDeleteCmd() *cobra.Command {
 }
 
 const LogControlConfigScaffoldYAML = `api_version: v1/config
-kind: LogControlConfigs
+kind: LogControlConfig
 spec:
     # Control Rules are the ordered list of control rules.
     rules:

--- a/src/generated/cli/configv1/trace_behavior_config.gen.go
+++ b/src/generated/cli/configv1/trace_behavior_config.gen.go
@@ -345,7 +345,7 @@ func newTraceBehaviorConfigDeleteCmd() *cobra.Command {
 }
 
 const TraceBehaviorConfigScaffoldYAML = `api_version: v1/config
-kind: TraceBehaviorConfigs
+kind: TraceBehaviorConfig
 spec:
     # List of assignments for the main behavior. The referenced datasets will be
     # enrolled in behaviors. The referenced behaviors are the active behaviors for the

--- a/tools/pkg/clispec/clispec.go
+++ b/tools/pkg/clispec/clispec.go
@@ -181,18 +181,16 @@ func (e *Entity) scaffoldingKindName() string {
 	if entityKind == "Slo" {
 		return "SLO"
 	}
-
-	// Set of singleton entity kinds that should not be pluralized.
-	nonPluralSingletons := map[string]bool{
-		"OtelMetricsIngestion": true,
-		"LogIngestConfig":      true,
-		"LogBudget":            true,
+	// Set of singleton entity kinds that are pluralized.
+	// By default, singletons are assumed to be singular, but a few
+	// singletons are naturally plural.
+	pluralSingletons := map[string]bool{
+		"ResourcePool":          true,
+		"TraceTailSamplingRule": true,
 	}
-
-	if e.IsSingleton && !nonPluralSingletons[entityKind] {
-		entityKind = inflect.Pluralize(entityKind)
+	if pluralSingletons[entityKind] {
+		return inflect.Pluralize(entityKind)
 	}
-
 	return entityKind
 }
 


### PR DESCRIPTION
Invert the current allowlist for non-plural singletons
because non-plural is the reasonable default;
plural singletons are the exception.