### PR TITLE
fix make gen

### DIFF
--- a/src/generated/cli/configv1/consumption_config.gen.go
+++ b/src/generated/cli/configv1/consumption_config.gen.go
@@ -351,7 +351,34 @@ spec:
     # defined in order of precedence, where incoming requests are allocated to
     # the first partition that matches. Requests that don't match any
     # partition fall back to an omnipresent default partition.
-    partitions: []
+    partitions:
+        - # name is a human-readable name of the partition. Must be unique within the
+          # parent partition. You can modify this value after the partition is created.
+          name: <string>
+          # filters define what data matches the partition. The filters are AND'd
+          # together; a request must match every filter in order to match the
+          # partition. Must not be empty.
+          filters:
+            - # conditions are the conditions to match.
+              conditions:
+                - # If set, matches data which belongs to the given dataset. Cannot set if
+                  # log_filter is set.
+                  dataset_slug: <string>
+                  log_filter:
+                    # Returns logs that match this query. The query can include only top-level
+                    # operations. Nested clauses aren't supported. Only one type of 'AND' or 'OR'
+                    # operator is allowed.
+                    query: <string>
+              operator: <IN|NOT_IN>
+          # partitions are the optional child partitions of this partition. If set,
+          # requests which match the current partition will be allocated to the
+          # first child partition that matches. Requests that don't match any child
+          # partition fall back to an omnipresent default child partition.
+          partitions: []
+          # slug is the immutable identifier of the partition. Must be unique within
+          # the parent partition. You can not modify this value after the partition
+          # is created.
+          slug: <string>
 `
 
 func newConsumptionConfigScaffoldCmd() *cobra.Command {

--- a/tools/pkg/clispec/scaffold.go
+++ b/tools/pkg/clispec/scaffold.go
@@ -16,7 +16,6 @@ package clispec
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/chronosphereio/chronoctl-core/src/thirdparty/yaml"
@@ -75,16 +74,14 @@ func newArrayNode(schema spec.Schema) *yaml.Node {
 		return node
 	}
 	if schema.Items.Schema != nil {
-		if len(schema.Items.Schema.Type) == 0  {
+		if len(schema.Items.Schema.Type) == 0 {
 			// TODO(codyg): Swagger doesn't render recursive types correctly,
 			// see https://github.com/swagger-api/swagger-ui/issues/3325. This
 			// means scaffold won't work for recursive types.
 			//
-			// I'm sniping "ConsumptionConfigPartition" here, which is a
-			// recursive array element which has an empty schema.
-			fmt.Fprintf(
-				os.Stderr, "[WARN] scaffold: skipping recursive schema: %s\n",
-				schema.Items.Schema.Ref.String())
+			// If you hit this, then you need to modify removeRecursiveFields in
+			// specscanner to remove the recursive field's "items" key.
+			panic("recursive schema")
 		} else {
 			node.Content = append(node.Content, newNode(*schema.Items.Schema))
 		}


### PR DESCRIPTION
Strip the recursive `partitions` field from spec.json,
when generating the CLI, to avoid a non-deterministic recursion
where sometimes the Go schema has the recursive
reference resolved, and sometimes it doesn't.