### PR TITLE
Update swagger files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.25.x'
+        go-version: '1.26.x'
 
     - name: Build
       run: make chronoctl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 Added:
 * Add `metric_filters` and `trace_filter` fields to `v1/config/ConsumptionConfig` partition filter conditions.
 * Add `METRIC_PERSISTED_SERIES` and `METRIC_ALL` SKU groups and `CREDITS` unit to `v1/config/ConsumptionBudget`.
+* Add `parse_field` rule type to `v1/config/LogControlConfig`.
+* Add `grok_parser` to `v1/config/LogIngestConfig`.
+* Upgrade to Go 1.26.
 
 ## v1.25.0
 

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ chronoctl:
 go-version-check:
 	# make sure you're running the right version of Go, otherwise builds/codegen/tests
 	# may have inconsistent results that are hard to debug.
-	go version | grep go1.25 || (echo "Error: you must be running go1.25.x" && exit 1)
+	go version | grep go1.26 || (echo "Error: you must be running go1.26.x" && exit 1)
 
 .PHONY: release
 release:

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Chronoctl also provides commands to review state in Chronosphere:
 
 ## Building
 
-To build chronoctl, you must have Go 1.25 installed. A download link can be found at
+To build chronoctl, you must have Go 1.26 installed. A download link can be found at
 [go.dev](https://go.dev/doc/install).
 
 Run `make chronoctl` to build the binary. It will be found under

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/chronosphereio/chronoctl-core
 
-go 1.25
+go 1.26
 
 // Required to avoid picking up https://github.com/go-openapi/strfmt/commit/b36a4901fcb51dbf4300a5a6b60b4335440aa208
 // which causes strfmt.DateTime values to be incorrectly omitted from yaml output due to a bug in the yaml library

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/chronosphereio/chronoctl-core/tools
 
-go 1.25
+go 1.26
 
 replace github.com/chronosphereio/chronoctl-core => ../
 


### PR DESCRIPTION
* Upgrade to go 1.26
* Update swagger files
* Updates to get clean lint, build, and tests
