### PR TITLE
Add CHRONOSPHERE_USER_AGENT env var to override User-Agent header

### DIFF
--- a/src/cmd/pkg/client/client.go
+++ b/src/cmd/pkg/client/client.go
@@ -134,6 +134,7 @@ func (f *Flags) Transport(component transport.Component, basePath string) (*http
 		DefaultBasePath:    basePath,
 		EntityNamespace:    f.getEntityNamespace(),
 		Actor:              f.getActor(),
+		UserAgent:          f.getUserAgent(),
 	})
 	if err != nil {
 		return nil, err
@@ -194,6 +195,10 @@ func (f *Flags) getEntityNamespace() string {
 
 func (f *Flags) getActor() string {
 	return os.Getenv(env.ChronosphereActor)
+}
+
+func (f *Flags) getUserAgent() string {
+	return os.Getenv(env.ChronosphereUserAgent)
 }
 
 func (f *Flags) getAPIToken(apiURL string) (string, error) {

--- a/src/cmd/pkg/env/env.go
+++ b/src/cmd/pkg/env/env.go
@@ -26,4 +26,6 @@ const (
 	ChronosphereEntityNamespace = "CHRONOSPHERE_ENTITY_NAMESPACE"
 	// ChronosphereActor is the environment variable that specifies the Chronosphere actor
 	ChronosphereActor = "CHRONOSPHERE_ACTOR"
+	// ChronosphereUserAgent is the environment variable that overrides the User-Agent header
+	ChronosphereUserAgent = "CHRONOSPHERE_USER_AGENT"
 )

--- a/src/cmd/pkg/transport/transport.go
+++ b/src/cmd/pkg/transport/transport.go
@@ -58,6 +58,7 @@ type RuntimeConfig struct {
 	DefaultBasePath    string
 	EntityNamespace    string
 	Actor              string
+	UserAgent          string
 }
 
 // New creates a new HTTP transport that can communicate with the Chronosphere API.
@@ -95,7 +96,7 @@ func New(config RuntimeConfig) (*httptransport.Runtime, error) {
 	transport.DefaultAuthentication = httptransport.APIKeyAuth(apiTokenHeader, "header", config.APIToken)
 
 	transport.Transport = xswagger.WithRequestIDTrailerTransport(
-		withCustomHeaders(config.Component, config.EntityNamespace, config.Actor, transport.Transport),
+		withCustomHeaders(config.Component, config.EntityNamespace, config.Actor, config.UserAgent, transport.Transport),
 	)
 	transport.Consumers[httpruntime.JSONMime] = xswagger.JSONConsumer()
 	transport.Consumers[httpruntime.HTMLMime] = xswagger.TextConsumer()
@@ -116,21 +117,26 @@ type CustomHeaderTransport struct {
 	Rt              http.RoundTripper
 }
 
-func withCustomHeaders(component Component, entityNamespace string, actor string, rt http.RoundTripper) http.RoundTripper {
+func withCustomHeaders(component Component, entityNamespace string, actor string, userAgent string, rt http.RoundTripper) http.RoundTripper {
 	if rt == nil {
 		rt = http.DefaultTransport
 	}
 
-	return CustomHeaderTransport{
-		Rt: rt,
-		agent: fmt.Sprintf("%s/%v-%v (%s; %s; %s)",
+	agent := userAgent
+	if agent == "" {
+		agent = fmt.Sprintf("%s/%v-%v (%s; %s; %s)",
 			component,
 			buildinfo.Version,
 			buildinfo.SHA,
 			runtime.Version(),
 			runtime.GOOS,
 			runtime.GOARCH,
-		),
+		)
+	}
+
+	return CustomHeaderTransport{
+		Rt:              rt,
+		agent:           agent,
 		entityNamespace: entityNamespace,
 		actor:           actor,
 	}


### PR DESCRIPTION
The User-Agent header was previously hardcoded
from the component name and build info, with
no way to override it at runtime. This adds a
CHRONOSPHERE_USER_AGENT env var that, when set,
replaces the default User-Agent header value.
Follows the same pattern as CHRONOSPHERE_ENTITY_NAMESPACE
and CHRONOSPHERE_ACTOR.