### PR TITLE
Ignore local Claude files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,9 @@ dist/
 
 # Docs directory
 site/
+
+# Claude
+.claude/settings.local.json
+.claude/scheduled_tasks.lock
+.claude/worktrees/
+CLAUDE.local.md


### PR DESCRIPTION
Local Claude editor/session files (settings, scheduled-task lock,
worktrees, and `CLAUDE.local.md`) are currently untracked noise that
shows up in `git status`.

Adds a `# Claude` section to `.gitignore` covering these local files so
they stay out of the repo.